### PR TITLE
Swerve Current and Joystick input Limits

### DIFF
--- a/src/main/java/frc/robot/Konstants.java
+++ b/src/main/java/frc/robot/Konstants.java
@@ -409,7 +409,7 @@ public final class Konstants
         // Controller constraints
         public static final double kDriveCoeff       = 0.95;
         public static final double kRotationCoeff    = 0.95;
-        public static final double kJoystickDeadband = 0.1;
+        public static final double kJoystickDeadband = 0.15;
         public static final double kSlowModePercent  = 0.2;
         
         public static final double kAccelLimit = 2;

--- a/src/main/java/frc/robot/TunerConstants.java
+++ b/src/main/java/frc/robot/TunerConstants.java
@@ -55,7 +55,18 @@ public class TunerConstants {
 
     // Initial configs for the drive and steer motors and the azimuth encoder; these cannot be null.
     // Some configs will be overwritten; check the `with*InitialConfigs()` API documentation.
-    private static final TalonFXConfiguration driveInitialConfigs = new TalonFXConfiguration();
+    private static final TalonFXConfiguration driveInitialConfigs = new TalonFXConfiguration()
+        .withCurrentLimits(
+        new CurrentLimitsConfigs()
+            .withSupplyCurrentLimit(70.0) // Amps
+            .withSupplyCurrentLowerLimit(50) // Amps
+            .withSupplyCurrentLowerTime(0.5) // Seconds
+            .withSupplyCurrentLimitEnable(true)
+
+            .withStatorCurrentLimit(60) // Amps
+            .withStatorCurrentLimitEnable(true)
+        );
+
     private static final TalonFXConfiguration steerInitialConfigs = new TalonFXConfiguration()
         .withCurrentLimits(
             new CurrentLimitsConfigs()

--- a/src/main/java/frc/robot/bindings/SKSwerveBinder.java
+++ b/src/main/java/frc/robot/bindings/SKSwerveBinder.java
@@ -17,7 +17,9 @@ import static frc.robot.Ports.DriverPorts.kDriveFn;
 // Filters used for input types (specifically Axis inputs)
 import frc.robot.utils.filters.DeadbandFilter;
 import frc.robot.utils.filters.Filter;
+import frc.robot.utils.filters.DriveStickFilter;
 import lombok.Getter;
+import edu.wpi.first.math.filter.SlewRateLimiter;
 // Used for binding buttons to drive actions
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
@@ -31,6 +33,9 @@ import java.util.Optional;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
+
+import frc.robot.preferences.Pref;
+import frc.robot.preferences.SKPreferences;
 
 /* Leftover code from Phoenix's configureBindings():
     joystick.a().whileTrue(m_swerve.get().applyRequest(() -> brake));
@@ -48,9 +53,25 @@ import com.ctre.phoenix6.swerve.SwerveRequest;
 
 public class SKSwerveBinder implements CommandBinder{
     Optional<SKSwerve>  m_drive;
+    DriveStickFilter translationXFilter;
+    DriveStickFilter translationYFilter;
+    DriveStickFilter rotationFilter;
+
+     Pref<Double> driverTranslationSlewPref = SKPreferences.attach("driverTranslSlew", 1.5)
+                 .onChange((newValue) -> {
+                     translationXFilter.setSlewRate(newValue);
+                     translationYFilter.setSlewRate(newValue);
+                 });
+    
+
+    
+    Pref<Double> driverRotationSlewPref = SKPreferences.attach("driverRotSlew", 4.0)
+                .onChange((newValue) -> {
+                    rotationFilter.setSlewRate(newValue);
+                });
 
     @Getter private double MaxSpeed = TunerConstants.kSpeedAt12Volts.in(MetersPerSecond); // kSpeedAt12Volts desired top speed
-    private double MaxAngularRate = RotationsPerSecond.of(0.75).in(RadiansPerSecond); // 3/4 of a rotation per second max angular velocity
+    @Getter private double MaxAngularRate = RotationsPerSecond.of(0.75).in(RadiansPerSecond); // 3/4 of a rotation per second max angular velocity
 
     // Driver Buttons
     public final Trigger fn = kDriveFn.button;
@@ -63,7 +84,7 @@ public class SKSwerveBinder implements CommandBinder{
 
 
     private final SwerveRequest.FieldCentric drive = new SwerveRequest.FieldCentric()
-            .withDeadband(0).withRotationalDeadband(0)
+            .withDeadband(kJoystickDeadband).withRotationalDeadband(kJoystickDeadband)
             .withDriveRequestType(DriveRequestType.OpenLoopVoltage); // Use open-loop control for drive motors
     private final SwerveRequest.SwerveDriveBrake brake = new SwerveRequest.SwerveDriveBrake();
     private final SwerveRequest.PointWheelsAt point = new SwerveRequest.PointWheelsAt();
@@ -71,6 +92,10 @@ public class SKSwerveBinder implements CommandBinder{
 
     public SKSwerveBinder(Optional<SKSwerve> m_drive) {
         this.m_drive = m_drive;
+        this.translationXFilter = new DriveStickFilter(MaxSpeed, driverTranslationSlewPref.get(), kJoystickDeadband);
+        this.translationYFilter = new DriveStickFilter(MaxSpeed, driverTranslationSlewPref.get(), kJoystickDeadband);
+
+        this.rotationFilter = new DriveStickFilter(MaxAngularRate, driverRotationSlewPref.get(), kJoystickDeadband);
     }
 
 
@@ -79,16 +104,13 @@ public class SKSwerveBinder implements CommandBinder{
         if (m_drive.isPresent())
         {
             SKSwerve drivetrain = m_drive.get();
-
-            // Sets filters for driving axes
-            // kTranslationXPort.setFilter(new CubicDeadbandFilter(kDriveCoeff,
-            //     kJoystickDeadband, SwerveConstants.kMaxDriveSpeedMetersPerSecond, true));
-
-            // kTranslationYPort.setFilter(new CubicDeadbandFilter(kDriveCoeff,
-            //     kJoystickDeadband, SwerveConstants.kMaxDriveSpeedMetersPerSecond, true));
             
-            // kVelocityOmegaPort.setFilter(new CubicDeadbandFilter(kRotationCoeff, kJoystickDeadband,
-            //     Math.toRadians(SwerveConstants.kMaxModuleAngularSpeedDegreesPerSecond), true));
+            // Sets filters for driving axes
+             kTranslationXPort.setFilter(translationXFilter);
+
+             kTranslationYPort.setFilter(translationYFilter);
+            
+            kVelocityOmegaPort.setFilter(rotationFilter);
 
             slowmode.
                 onTrue(new InstantCommand(() -> {setGainCommand(kSlowModePercent);}, drivetrain))
@@ -106,14 +128,14 @@ public class SKSwerveBinder implements CommandBinder{
         //             () -> {return true;}, 
         //             drive));
 
-        drivetrain.setDefaultCommand(
-            // Drivetrain will execute this command periodically
-            drivetrain.applyRequest(() ->
-                drive.withVelocityX(kTranslationXPort.getFilteredAxis() * MaxSpeed) // Drive forward with negative Y (forward)
-                    .withVelocityY(kTranslationYPort.getFilteredAxis() * MaxSpeed) // Drive left with negative X (left)
-                    .withRotationalRate(kVelocityOmegaPort.getFilteredAxis() * MaxAngularRate) // Drive counterclockwise with negative X (left)
-            )
-        );
+            drivetrain.setDefaultCommand(
+                // Drivetrain will execute this command periodically
+                drivetrain.applyRequest(() -> {
+                    return drive.withVelocityX(kTranslationXPort.getFilteredAxis()) // Drive forward with negative Y (forward)
+                        .withVelocityY(kTranslationYPort.getFilteredAxis()) // Drive left with negative X (left)
+                        .withRotationalRate(kVelocityOmegaPort.getFilteredAxis()); // Drive counterclockwise with negative X (left)
+                })
+            );
         }
     }
 

--- a/src/main/java/frc/robot/utils/filters/DriveStickFilter.java
+++ b/src/main/java/frc/robot/utils/filters/DriveStickFilter.java
@@ -1,0 +1,32 @@
+package frc.robot.utils.filters;
+
+import edu.wpi.first.math.filter.SlewRateLimiter;
+
+public class DriveStickFilter implements Filter {
+    private double MaxSpeed;
+
+    private DeadbandFilter deadbandFilter;
+    private SlewRateLimiter slewRateFilter;
+        
+            public DriveStickFilter(double MaxSpeed, double slewRate, double deadband) {
+                this.MaxSpeed = MaxSpeed;
+                
+                setDeadband(deadband);
+                setSlewRate(slewRate);
+        }
+    
+        @Override
+        public double filter(double rawAxis) {
+            double processedAxis = deadbandFilter.filter(rawAxis);
+            return slewRateFilter.calculate(processedAxis) * MaxSpeed;
+        }
+    
+    
+        public void setDeadband(double deadband) {
+            this.deadbandFilter = new DeadbandFilter(deadband);
+        }
+    
+        public void setSlewRate(double slewRate) {
+            this.slewRateFilter = new SlewRateLimiter(slewRate);
+    }
+}


### PR DESCRIPTION
Adds swerve current limits and a slew rate to the driver's swerve drive joysticks. There is some carryover from other vision subsystem files, but none are initialized or used so there will be no errors or problems caused by them.